### PR TITLE
Set the max age for cookies

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,9 @@ let sess = {
   secret: process.env.SESSION_SECRET,
   resave: false,
   saveUninitialized: false,
-  cookie: {}
+  cookie: {
+    maxAge: 30 * 24 * 60 * 60 * 1000 // 30 days
+  }
 }
 
 if (process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
Set the max age for cookies to 30 days (has to be given in millisecs).
I couldn't test the change since I don't have the necessary Discord API keys.